### PR TITLE
Fix arch option setting

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -121,7 +121,7 @@ func prepare() {
 	arch := build.Default.GOARCH
 
 	if options.Has(OPT_ARCH) {
-		arch = options.GetS(arch)
+		arch = options.GetS(OPT_ARCH)
 	}
 
 	inspect.Sizes = types.SizesFor("gc", arch)
@@ -137,7 +137,6 @@ func process(args options.Arguments) {
 	dirs := args.Strings()[1:]
 
 	report, err := inspect.ProcessSources(dirs)
-
 	if err != nil {
 		printErrorAndExit(err.Error())
 	}


### PR DESCRIPTION

Signed-off-by: Andrew Thornton <art27@cantab.net>

### What did you implement:

There is a small bug in the option getting code where instead of getting the value of the "-a"/"--arch" option, it attempts to get the value of the "--"GOARCH option.

This PR simply changes this code to pass the option name instead.

### How can we verify it:

Try running `aligo -a 386` 

### TODO's:

- [ ] Write tests - NA
- [ ] Write documentation - NA
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [ ] Provide verification config / commands - NA
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**Is this ready for review?:** Yes
**Is it a breaking change?:** No
