### PR TITLE
Fix byte position error when aligning memory

### DIFF
--- a/cli/render.go
+++ b/cli/render.go
@@ -282,6 +282,11 @@ func printCurrentFieldsInfo(fields []*report.Field) {
 
 		fmt.Print(strings.Repeat("  ", int(counter+1)))
 
+		for counter%field.Size != 0 {
+			fmtc.Printf("{r}□ {!}")
+			counter++
+		}
+
 		for i := int64(0); i < field.Size; i++ {
 			fmtc.Printf("{g}■ {!}")
 


### PR DESCRIPTION
### What did you implement:
Fix byte position error when aligning memory
Closes #XXXXX


### How did you implement it:
A judgment is made when rendering the memory location of each field. When the current rendering position is that the remainder of the memory size occupied by the field is not equal to 0, an empty memory placeholder needs to be used.
...

### How can we verify it:
use specify struct can verify
`
type Test struct {
    A int8
    B int32
    E bool
    F int16
    C int32
}
`

origin show memory location
![image](https://github.com/essentialkaos/aligo/assets/62538535/853aa24a-b2e4-4742-8ee0-9f322d7e9c41)

after modify, show memory location
![image](https://github.com/essentialkaos/aligo/assets/62538535/03d00500-7798-48fe-9767-f364bfeafd66)

...

### TODO's:

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**Is this ready for review?:** Yes
**Is it a breaking change?:** No
Please merge it to fix this problem, Thank you very much.
