### PR TITLE
Fix two panics

### DIFF
--- a/cli/render.go
+++ b/cli/render.go
@@ -283,6 +283,12 @@ func printCurrentFieldsInfo(fields []*report.Field) {
 
 		fmt.Print(strings.Repeat("  ", int(counter+1)))
 
+		// Ensure we don't panic when hitting an empty struct{}.
+		if field.Size == 0 {
+			fmtc.NewLine()
+			continue
+		}
+
 		for counter%field.Size != 0 {
 			fmtc.Printf("{r}□{!} ")
 			counter++

--- a/inspect/inspect.go
+++ b/inspect/inspect.go
@@ -186,7 +186,8 @@ func getStructReport(info *structInfo) *report.Struct {
 		Ignore:   info.Skip,
 	}
 
-	numFields := info.Type.NumFields()
+	// Use AST fields list length, otherwise List[i] below can panic.
+	numFields := len(info.AST.Fields.List)
 
 	for i := 0; i < numFields; i++ {
 		f := info.Type.Field(i)


### PR DESCRIPTION
This PR fixes two separate panics that were both reproducible by trying to view structs in `github.com/nats-io/nats-server/v2/server`, the first with embedded empty structs and the other with an overflow of the AST field list.