### PR TITLE
feat: basic pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+---
+- id: aligo-check
+  name: Aligo
+  description: Check Golang struct alignment info
+  entry: aligo check
+  language: golang
+  types: [go]


### PR DESCRIPTION
This allows users to share aligo locally with other maintainers + a simple way to introduce in CI w/ standardized caching, test selection, etc.

I tested this locally using a rev from my branch,

<img width="2880" height="1920" alt="20251210_20h26m42s_grim" src="https://github.com/user-attachments/assets/01e53100-55d5-42a3-a21c-356ad5b49830" />


Checked:
- Passes at HEAD
- Fails if struct is misaligned
- Is skipped if non-golang file is changed